### PR TITLE
fix undefined request

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -185,6 +185,10 @@ const Table = ({
   };
 
   const handleROwClick = async (rowId) => {
+    if (!rowId) {
+      return;
+    }
+    
     setSelectedRow(rowId);
     selectedRowRef.current = rowId;
 


### PR DESCRIPTION
Фикс ошибки undefined в запросе. Иногда проскакивает undefined в методе `handleROwClick`. Добавил проверку на то чтоб всегда был `rowId` для выполнения кода в методе